### PR TITLE
fix(theme): Add missing CTkFont key to theme.json

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -2,6 +2,14 @@
   "CTk": {
     "fg_color": ["#F2F2F7", "#1F1F1F"]
   },
+  "CTkFont": {
+    "family": "sans-serif",
+    "size": 13,
+    "weight": "normal",
+    "slant": "roman",
+    "underline": 0,
+    "overstrike": 0
+  },
   "CTkFrame": {
     "corner_radius": 6,
     "border_width": 1,


### PR DESCRIPTION
The application was crashing on startup with a `KeyError: 'CTkFont'` because the custom theme file `theme.json` was missing the required `CTkFont` definition.

This change adds the `CTkFont` key with default values to `theme.json`, allowing the `customtkinter` library to correctly load the font configuration and preventing the application from crashing.